### PR TITLE
Fix HP bar rendering when enemy is defeated

### DIFF
--- a/DarkUnder_Battle.ino
+++ b/DarkUnder_Battle.ino
@@ -168,7 +168,13 @@ uint16_t battleLoop() {
         font3x5.print(F(" DAMAGE!\n"));
         font3x5.setCursor(32, 24);
         font3x5.print(hpLoss);
-        if (enemies[attackingEnemyIdx].getHitPoints() > hpLoss) { enemies[attackingEnemyIdx].setHitPoints(enemies[attackingEnemyIdx].getHitPoints() - hpLoss); } else { enemies[attackingEnemyIdx].setEnabled(false); }
+        if (enemies[attackingEnemyIdx].getHitPoints() > hpLoss) {
+            enemies[attackingEnemyIdx].setHitPoints(enemies[attackingEnemyIdx].getHitPoints() - hpLoss);
+        }
+        else {
+            enemies[attackingEnemyIdx].setHitPoints(0);
+            enemies[attackingEnemyIdx].setEnabled(false);
+        }
 
         gameState = GameState::Battle_EnemyDies;
         if (enemies[attackingEnemyIdx].getEnabled()) { gameState = GameState::Battle_EnemyAttacks_Init; }

--- a/DarkUnder_Render.ino
+++ b/DarkUnder_Render.ino
@@ -761,6 +761,9 @@ void drawEnemyHitPointsBar(uint8_t hitPoints, uint8_t hitPointsMax) {
   arduboy.drawCompressed(3, 49, fight_HP_bar_Mask, BLACK);
   arduboy.drawCompressed(3, 49, fight_HP_bar, WHITE);
   
+  if(hitPoints == 0)
+    return;
+  
   const uint32_t hp = static_cast<uint32_t>(hitPoints) << 16; // U16x16
   const uint16_t hpMax = static_cast<uint16_t>(hitPointsMax) << 8; // U8x8
   const uint32_t divResult = hp / hpMax; // U8x8


### PR DESCRIPTION
Enemy hp wasn't being reduced to zero and hp bar wasn't drawing correctly when it was.